### PR TITLE
Basic giphy bot support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.giphy-api-key.txt

--- a/giphy.py
+++ b/giphy.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+import time
+import giphy_client
+from giphy_client.rest import ApiException
+
+def giphy(tag):
+    api_instance = giphy_client.DefaultApi()
+    api_key = open(".giphy-api-key.txt", "r").read().rstrip()
+    fmt = 'json' 
+    rating = 'g' 
+    try: 
+        api_response = api_instance.gifs_random_get(api_key, tag=tag, rating=rating, fmt=fmt)
+        return api_response.data.image_url
+    except ApiException as e:
+        print("Exception when calling DefaultApi->gifs_search_get: %s\n" % e)
+
+if __name__ == "__main__":
+    print(giphy("cake"))


### PR DESCRIPTION
Adds a basic `giphy` function that tags a string as an argument that indicates what you want a random gif of. In the case of Cakebot this would likely be "cake" :-)

`giphy.py` can be run on its own from the command line for testing:

```
$ python3 giphy.py
https://media2.giphy.com/media/hSeAVWkrAzhRu/giphy.gif
````

or as imported simply as the `giphy` function, for example:

```python
async def cake(ctx):
    await ctx.send(embed = discord.Embed().set_image(url = giphy('cake'))
```

The giphy api key is loaded from a file that should be called `.giphy-api-key.txt`. A `.gitignore` is added to exclude this file from being checked in.